### PR TITLE
Add security audit strategy

### DIFF
--- a/audit-plan.md
+++ b/audit-plan.md
@@ -1,0 +1,48 @@
+# Security Audit Strategy
+
+## Objective
+Develop a repeatable approach to analyze project documentation and source code for security vulnerabilities across the `bft` and `monad` components.
+
+## Plan
+
+1. **Scope Confirmation**
+   - Review `scope.txt` to understand in-scope modules and files.
+   - Note excluded components to focus efforts on relevant code paths.
+
+2. **Documentation Review**
+   - Read `README.md` and linked references to understand architecture, threat model, and known deviations from Ethereum.
+   - Identify stated assumptions, invariants, and out-of-scope items that influence security analysis.
+
+3. **Threat Modeling**
+   - Enumerate assets and trust boundaries for consensus, networking, execution, and storage layers.
+   - Use STRIDE to map potential threats against each component.
+
+4. **Static Analysis**
+   - Run `cargo clippy` and `cargo audit` for Rust crates under `bft`.
+   - For C/C++ code in `monad`, run `clang-tidy` and `cppcheck`.
+   - Track any compiler warnings or unsafe constructs.
+
+5. **Manual Code Review**
+   - Perform line-by-line inspection of high‑risk modules listed in `scope.txt`, prioritizing consensus logic, networking, and database handling.
+   - Look for logic errors, missing input validation, and unsafe `unsafe` blocks in Rust.
+
+6. **Dependency & Configuration Analysis**
+   - Review Cargo manifests and build scripts for outdated or unpinned dependencies.
+   - Examine configuration defaults for insecure settings or missing validation.
+
+7. **Dynamic & Fuzz Testing**
+   - Execute available unit and integration tests; add missing cases for edge conditions and failure scenarios.
+   - Apply fuzzing (e.g., `cargo fuzz`, `libFuzzer`) on serialization, networking, and VM components.
+
+8. **Evaluation of External Interfaces**
+   - Inspect RPC endpoints and CLI tools for injection vectors, DoS potential, and improper authentication.
+   - Review inter-process communication channels for exposure of sensitive data.
+
+9. **Reporting**
+   - Document findings with severity, impact, and reproduction steps.
+   - Provide remediation recommendations and track follow-up actions.
+
+## Deliverables
+- Comprehensive report detailing vulnerabilities, mitigation strategies, and coverage notes.
+- Recommendations for ongoing security testing within CI/CD pipelines.
+


### PR DESCRIPTION
## Summary
- document strategy to audit docs and code for security vulnerabilities

## Testing
- `cargo test --workspace` *(fails: failed to load source for dependency `agent`)*
- `./monad/scripts/configure.sh` *(fails: source directory does not contain CMakeLists.txt)*
- `./monad/scripts/build.sh` *(fails: `/workspace/2025-09-monad/build` is not a directory)*
- `./monad/scripts/test.sh` *(fails: failed to change working directory to `/workspace/2025-09-monad/build`)*

------
https://chatgpt.com/codex/tasks/task_e_68c8fd61c8bc832490aeb6d9c54a79a3